### PR TITLE
이메일에서 배럴 파일 사용하지 않음

### DIFF
--- a/apps/website/src/lib/server/email/index.ts
+++ b/apps/website/src/lib/server/email/index.ts
@@ -1,5 +1,5 @@
 import { SendEmailCommand } from '@aws-sdk/client-ses';
-import { aws } from '../external-api';
+import * as aws from '../external-api/aws';
 import type { ComponentProps, ComponentType, SvelteComponent } from 'svelte';
 
 type SendEmailParams<T extends SvelteComponent> = {


### PR DESCRIPTION
external-api 배럴에서 무언가 스크립트로 실행시 svg 임포트 오류가 나는 것으로 추정